### PR TITLE
Aligned with New CIP-30 Extension Scheme

### DIFF
--- a/CIP-0062/README.md
+++ b/CIP-0062/README.md
@@ -254,10 +254,10 @@ The following endpoints extend [CIP-30's Full API](https://github.com/cardano-fo
 Except `signVotes`, no other method should require any user
 interaction as the user has already consented to the dApp reading information
 about the wallet's state when they agreed to
-[`cardano.{walletName}.catalyst.enable()`](#cardanowalletnamecatalystenablepurpose-votingpurpose-promiseapi).
+[`cardano.{walletName}.enable()`](#cardanowalletnamecatalystenablepurpose-votingpurpose-promiseapi).
 The remaining methods
 [`api.signVotes()`](#apisignvotesvotes-vote-promisebytes) and
-[`api.signData()`](#apisubmitdelegationdelegation-delegation-promisesigneddelegationmetadata)
+[`api.submitDelegation()`](#apisubmitdelegationdelegation-delegation-promisesigneddelegationmetadata)
 must request the user's consent in an informative way for each and every API
 call in order to maintain security.
 
@@ -269,7 +269,7 @@ state to work.
 
 Errors: [`APIError`](#extended-apierror)
 
-This is a chance for dApps to ask wallets what `VotingPurpose`s the user wishes to allow the dApp access to. It is up to wallet implementors if they deem it necessary to prompt the user for their permission to share supported Purposes.
+This is a chance for dApps to ask wallets what `VotingPurpose`s they support.
 
 This information should be tracked by the dApp and used in subsequent api calls.
 

--- a/CIP-0062/README.md
+++ b/CIP-0062/README.md
@@ -265,7 +265,7 @@ The API chosen here is for the minimum API necessary for dApp <-> Wallet
 interactions without convenience functions that don't strictly need the wallet's
 state to work.
 
-#### api.getVotingPurposes(): Promise\<VotingPurpose>[]
+#### api.getVotingPurposes(): Promise\<VotingPurpose[]>
 
 Errors: [`APIError`](#extended-apierror)
 

--- a/CIP-0062/README.md
+++ b/CIP-0062/README.md
@@ -251,7 +251,7 @@ All TxSignErrors defined in [CIP-30](https://cips.cardano.org/cips/cip30/#txsign
 
 The following endpoints extend [CIP-30's Full API](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030#full-api).
 
-Except `signVotes`, no other method should require any user
+Except `signVotes` and `submitDelegation`, no other method should require any user
 interaction as the user has already consented to the dApp reading information
 about the wallet's state when they agreed to
 [`cardano.{walletName}.enable()`](#cardanowalletnamecatalystenablepurpose-votingpurpose-promiseapi).


### PR DESCRIPTION
### Context
- Following the merger of #446 CIP-30 contains a scheme for extensions to its API.
- This means that CIP-62 can use the scheme as defined in CIP-30 rather than its own namespace (catalyst).

### Changes
- Removed initial API components:
  - `cardano.{walletName}.catalyst.apiVersion`
  - `cardano.{walletName}.catalyst.enable(purpose: VotingPurpose[])`
- Added:
  - `api.getVotingPurposes()`

- Prose:
  - Added description of connection flow to `Examples of Message Flows and Processes`.
  - Added description of missing voting flow to `Examples of Message Flows and Processes`.
  - Supporting prose throughout .

----------------------------------------------------------

[Rendered Version](https://github.com/Ryun1/CIPs/tree/cip-62-extension-rewrite/CIP-0062)
